### PR TITLE
build: Bump PHP and dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -19,8 +21,6 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    - cron: '50 */8 * * *'
 
 env:
   COLUMNS: 120
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -65,7 +65,7 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -133,7 +133,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JBZoo / Path
 
-[![CI](https://github.com/JBZoo/Path/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Path/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Path/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Path?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Path/coverage.svg)](https://shepherd.dev/github/JBZoo/Path)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Path/level.svg)](https://shepherd.dev/github/JBZoo/Path)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/path/badge)](https://www.codefactor.io/repository/github/jbzoo/path/issues)    
+[![CI](https://github.com/JBZoo/Path/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Path/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Path/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Path?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Path/coverage.svg)](https://shepherd.dev/github/JBZoo/Path)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Path/level.svg)](https://shepherd.dev/github/JBZoo/Path)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/path/badge)](https://www.codefactor.io/repository/github/jbzoo/path/issues)
 [![Stable Version](https://poser.pugx.org/jbzoo/path/version)](https://packagist.org/packages/jbzoo/path/)    [![Total Downloads](https://poser.pugx.org/jbzoo/path/downloads)](https://packagist.org/packages/jbzoo/path/stats)    [![Dependents](https://poser.pugx.org/jbzoo/path/dependents)](https://packagist.org/packages/jbzoo/path/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/path)](https://github.com/JBZoo/Path/blob/master/LICENSE)
 
 
@@ -64,7 +64,7 @@ Path::clean('path\\to//simple\\folder');    //  result: 'path/to/simple/folder'
 See details [here](tests/phpbench/CompareWithRealpath.php)
 
 subject | groups | its | revs | mean | stdev | rstdev | mem_real | diff
- --- | --- | --- | --- | --- | --- | --- | --- | --- 
+ --- | --- | --- | --- | --- | --- | --- | --- | ---
 benchBaseline |  | 3 | 10000 | 2.53μs | 0.11μs | 4.39% | 6,291,456b | 1.00x
 benchNative |  | 3 | 10000 | 138.22μs | 0.46μs | 0.33% | 6,291,456b | 54.64x
 benchJBZooPath |  | 3 | 10000 | 192.58μs | 0.87μs | 0.45% | 6,291,456b | 76.13x

--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,14 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"         : "^8.1",
+        "php"         : "^8.2",
 
-        "jbzoo/utils" : "^7.1",
-        "jbzoo/data"  : "^7.1"
+        "jbzoo/utils" : "^7.3",
+        "jbzoo/data"  : "^7.2"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.1"
+        "jbzoo/toolbox-dev" : "^7.2"
     },
 
     "autoload"          : {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -16,6 +16,6 @@ declare(strict_types=1);
 
 namespace JBZoo\Path;
 
-class Exception extends \RuntimeException
+final class Exception extends \RuntimeException
 {
 }

--- a/src/Path.php
+++ b/src/Path.php
@@ -43,7 +43,7 @@ final class Path
     private array $paths = [];
 
     /** Root directory. */
-    private ?string $root;
+    private string $root;
 
     public function __construct(?string $root = null)
     {
@@ -83,7 +83,7 @@ final class Path
 
             $path = self::cleanPath($path);
             if ($path !== '' && !\in_array($path, $this->paths[$alias], true)) {
-                if (\preg_match('/^' . \preg_quote($alias . ':', '') . '/i', $path) > 0) {
+                if (\preg_match('/^' . \preg_quote($alias . ':', null) . '/i', $path) > 0) {
                     throw new Exception("Added looped path \"{$path}\" to key \"{$alias}\"");
                 }
 
@@ -109,7 +109,7 @@ final class Path
      * Get absolute path to a file or a directory.
      * @param string $source (example: "default:file.txt")
      */
-    public function glob(string $source): ?array
+    public function glob(string $source): array
     {
         $parsedSource = $this->parse($source);
 
@@ -131,12 +131,8 @@ final class Path
     /**
      * Get root directory.
      */
-    public function getRoot(): ?string
+    public function getRoot(): string
     {
-        if ($this->root === null) {
-            throw new Exception('Please, set the root directory');
-        }
-
         return $this->root;
     }
 
@@ -220,7 +216,11 @@ final class Path
     {
         $details = \explode('?', $source);
 
-        $path = $this->cleanPathInternal($details[0] ?? '');
+        if ($details[0] !== '') {
+            $path = $this->cleanPathInternal($details[0]);
+        } else {
+            throw new Exception("Invalid source: {$source}");
+        }
 
         if ($path !== '' && $path !== null) {
             $urlPath = $this->getUrlPath($path, true);
@@ -244,7 +244,7 @@ final class Path
      * Get relative path to file or directory.
      * @param string $source (example: "default:file.txt")
      */
-    public function rel(string $source): ?string
+    public function rel(string $source): string
     {
         $fullpath = (string)$this->get($source);
 
@@ -257,7 +257,7 @@ final class Path
      */
     public function relGlob(string $source): array
     {
-        $list = (array)$this->glob($source);
+        $list = $this->glob($source);
 
         foreach ($list as $key => $item) {
             $list[$key] = FS::getRelative($item, $this->root, '/');
@@ -278,7 +278,7 @@ final class Path
         $prefix      = (string)self::prefix($cleanedPath);
         $cleanedPath = \substr($cleanedPath, \strlen($prefix));
 
-        $parts = \array_filter(\explode('/', $cleanedPath), static fn ($value) => $value);
+        $parts = \array_filter(\explode('/', $cleanedPath), static fn ($value) => $value); // @phpstan-ignore-line
 
         foreach ($parts as $part) {
             if ($part === '..') {
@@ -350,7 +350,7 @@ final class Path
      */
     private function getUrlPath(string $path, bool $exitsFile = false): ?string
     {
-        if ($this->root === null || $this->root === '') {
+        if ($this->root === '') {
             throw new Exception('Please, setup the root directory');
         }
 
@@ -387,10 +387,10 @@ final class Path
     {
         $sourceParts = \explode(':', $source, 2);
 
-        $alias = $sourceParts[0] ?? '';
+        $alias = $sourceParts[0];
         $path  = $sourceParts[1] ?? '';
 
-        $path  = \ltrim($path, '\\/');
+        $path  = \ltrim($path, '\/');
         $paths = $this->resolvePaths($alias);
 
         return [$alias, $paths, $path];
@@ -441,7 +441,7 @@ final class Path
     private static function find(array|string $paths, string $file): ?string
     {
         $paths = (array)$paths;
-        $file  = \ltrim($file, '\\/');
+        $file  = \ltrim($file, '\/');
 
         foreach ($paths as $path) {
             $fullPath = self::clean($path . '/' . $file);
@@ -460,7 +460,7 @@ final class Path
     private static function findViaGlob(array|string $paths, string $file): array
     {
         $paths = (array)$paths;
-        $file  = \ltrim($file, '\\/');
+        $file  = \ltrim($file, '\/');
 
         $path = Arr::first($paths);
 

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -65,7 +65,7 @@ class PathTest extends PHPUnit
         $this->fs->mkdir($exportDir);
 
         $default->set('defau/lt', $defaultDir);
-        $import->set('Defau\\l//t', $importDir);
+        $import->set('Defau\l//t', $importDir);
         $export->set('()de~~fau+!#$lt', [
             $exportDir,
             $importDir,
@@ -93,30 +93,30 @@ class PathTest extends PHPUnit
         isSame("{$current}/{$name1}/file.txt", $default->url('default:\file.txt'));
         isSame("{$current}/{$name1}/file.txt", $default->url('default:/file.txt'));
         isSame("{$current}/{$name1}/file.txt", $default->url('default:////file.txt'));
-        isSame("{$current}/{$name1}/file.txt", $default->url('default:\\\\file.txt'));
+        isSame("{$current}/{$name1}/file.txt", $default->url('default:\\\file.txt'));
         isSame("{$current}/{$name1}/file.txt", $default->url($defaultDir . DS . 'file.txt'));
         isSame("{$current}/{$name1}/file.txt", $default->url($defaultDir . '///file.txt'));
-        isSame("{$current}/{$name1}/file.txt", $default->url($defaultDir . '\\\\file.txt'));
+        isSame("{$current}/{$name1}/file.txt", $default->url($defaultDir . '\\\file.txt'));
 
         isSame("{$current}/{$name2}/simple.txt", $import->url('Default:simple.txt'));
         isSame("{$current}/{$name2}/simple.txt", $import->url('Default:\simple.txt'));
         isSame("{$current}/{$name2}/simple.txt", $import->url('Default:/simple.txt'));
         isSame("{$current}/{$name2}/simple.txt", $import->url('Default:////simple.txt'));
-        isSame("{$current}/{$name2}/simple.txt", $import->url('Default:\\\\simple.txt'));
+        isSame("{$current}/{$name2}/simple.txt", $import->url('Default:\\\simple.txt'));
         isSame("{$current}/{$name2}/simple.txt", $import->url($importDir . DS . 'simple.txt'));
         isSame("{$current}/{$name2}/simple.txt", $import->url($importDir . '///simple.txt'));
-        isSame("{$current}/{$name2}/simple.txt", $import->url($importDir . '\\\\simple.txt'));
+        isSame("{$current}/{$name2}/simple.txt", $import->url($importDir . '\\\simple.txt'));
 
         isSame("{$current}/{$name3}/my-file.txt", $export->url('default:my-file.txt'));
         isSame("{$current}/{$name3}/my-file.txt", $export->url('default:\my-file.txt'));
         isSame("{$current}/{$name3}/my-file.txt", $export->url('default:/my-file.txt'));
         isSame("{$current}/{$name2}/simple.txt", $export->url('default:////simple.txt'));
-        isSame("{$current}/{$name2}/simple.txt", $export->url('default:\\\\simple.txt'));
+        isSame("{$current}/{$name2}/simple.txt", $export->url('default:\\\simple.txt'));
         isSame("{$current}/{$name3}/my-file.txt", $export->url($exportDir . DS . 'my-file.txt'));
         isSame("{$current}/{$name3}/my-file.txt", $export->url($exportDir . '///my-file.txt'));
-        isSame("{$current}/{$name3}/my-file.txt", $export->url($exportDir . '\\\\my-file.txt'));
+        isSame("{$current}/{$name3}/my-file.txt", $export->url($exportDir . '\\\my-file.txt'));
 
-        isSame("{$current}/{$name3}/my-file.txt?ver=123", $export->url($exportDir . '\\\\my-file.txt?ver=123'));
+        isSame("{$current}/{$name3}/my-file.txt?ver=123", $export->url($exportDir . '\\\my-file.txt?ver=123'));
 
         $this->fs->remove([$defaultDir, $importDir, $exportDir]);
     }
@@ -295,7 +295,7 @@ class PathTest extends PHPUnit
     {
         self::assertIsString(Path::prefix(__DIR__));
         self::assertIsString(Path::prefix(\dirname(__DIR__)));
-        self::assertIsString(Path::prefix('P:\\\\Folder\\'));
+        self::assertIsString(Path::prefix('P:\\\Folder\\'));
     }
 
     public function testNoPrefix(): void
@@ -364,10 +364,10 @@ class PathTest extends PHPUnit
 
         $this->is($file5, $this->path->get('default:simple/file.txt'));
         $this->is($file5, $this->path->get('default:simple\file.txt'));
-        $this->is($file5, $this->path->get('default:simple\\\\file.txt'));
+        $this->is($file5, $this->path->get('default:simple\\\file.txt'));
         $this->is($file5, $this->path->get('default:simple////file.txt'));
         $this->is($file5, $this->path->get('default:simple/file.txt'));
-        $this->is($file5, $this->path->get('default:\\simple/file.txt'));
+        $this->is($file5, $this->path->get('default:\simple/file.txt'));
         $this->is($file5, $this->path->get('default:\/simple/file.txt'));
 
         isNull($this->path->get('alias:/simple/file.txt'));
@@ -469,7 +469,7 @@ class PathTest extends PHPUnit
 
         $this->is($file1, $this->path->url('default:file1.txt'));
         $this->is($file3, $this->path->url('default:my-folder2/my-file.txt'));
-        $this->is($file3, $this->path->url('default:my-folder2\\\\my-file.txt'));
+        $this->is($file3, $this->path->url('default:my-folder2\\\my-file.txt'));
         $this->is($file3, $this->path->url('default:\my-folder2\my-file.txt'));
 
         $this->is($file1, $this->path->url($path2 . DS . 'file1.txt'));


### PR DESCRIPTION
- Upgrade PHP requirement from 8.1 to 8.2.
- Update `jbzoo/utils`, `jbzoo/data`, and `jbzoo/toolbox-dev` dependencies.
- Update CI workflows:
  - Bump PHP matrix to include 8.4 and remove 8.1.
  - Upgrade `actions/upload-artifact` to v4.
  - Remove scheduled cron job.
  - Add `contents: read` permission for security.
- Refactor `Exception` class to be `final`.
- Refactor `Path` class for stricter type hints and improved path handling.
- Adjust tests to align with updated path logic.